### PR TITLE
Skip empty request

### DIFF
--- a/src/UploadHandler.php
+++ b/src/UploadHandler.php
@@ -102,7 +102,9 @@ class UploadHandler
     {
         $files = [];
         foreach ($uploadedFiles as $name => $uploadedFile) {
-            if (is_array($uploadedFile)) {
+            if (!$uploadedFile) {
+                continue;
+            } elseif (is_array($uploadedFile)) {
                 $files[$name] = $this->processUploadedFiles($uploadedFile);
             } else {
                 $files[$name] = $this->processUploadedFile($uploadedFile);


### PR DESCRIPTION
Scenario:   
1. Send empty form (without choosen file field)  
2. Catch Fatal error: `Uncaught TypeError: Argument 1 passed to Slince\Upload\UploadHandler::processUploadedFile() must be an instance of Symfony\Component\HttpFoundation\File\UploadedFile, null given`  